### PR TITLE
chore: improve profile page

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -2,26 +2,18 @@
 
 The Cosmos org is collection of teams working on decentralized technology.
 
-## Repositories
+## Documentation
 
-### Go
+* [Cosmos SDK](https://docs.cosmos.network)
+* [IBC Go](https://ibc.cosmos.network)
+* [Cosmos Hub](https://hub.cosmos.network)
+* [Roadmaps](https://github.com/orgs/cosmos/projects)
 
-* [Cosmos SDK](https://github.com/cosmos/cosmos-sdk) - An SDK to develop a decentralized state machine
-    * Documentation can be found at [https://docs.cosmos.network/main](https://docs.cosmos.network/main)
-* [IBC-Go](https://github.com/cosmos/ibc-go) - An implementation of [IBC](https://github.com/cosmos/ibc) in [Go](https://go.dev)
-* [IAVL](https://github.com/cosmos/iavl) - An implementation of an immutable merkleized AVL tree
-* [Cosmos-db](https://github.com/cosmos/cosmos-db) - A library of databases which can be used as the database for a Cosmos state machine.
+## Participate
 
-### JS
-
-* [CosmJS](https://github.com/cosmos/cosmjs) - A library for interacting with Cosmos chains via JavaScript
-
-### Rust
-
-* [Cosmos-rust](https://github.com/cosmos/cosmos-rust) - A library for interacting with Cosmos chains via Rust.
-* [IBC-rs](https://github.com/cosmos/ibc-rs) - An implementation of [IBC](https://github.com/cosmos/ibc) in rust.
-* [IBC-proto-rs](https://github.com/cosmos/ibc-proto-rs) - A rust create for interacting with Cosmos and IBC structs
+* [Cosmos Hub Forum](https://forum.cosmos.network)
+* [Cosmos Discussions](https://github.com/orgs/cosmos/discussions)
 
 ---
 
-Discover the rest of the stack on [Awesome Cosmos](https://github.com/cosmos/awesome-cosmos).
+Discover all the stack on [Awesome Cosmos](https://github.com/cosmos/awesome-cosmos).

--- a/profile/README.md
+++ b/profile/README.md
@@ -4,6 +4,7 @@ The Cosmos org is collection of teams working on decentralized technology.
 
 ## Documentation
 
+* [Developer Portal](https://tutorials.cosmos.network/)
 * [Cosmos SDK](https://docs.cosmos.network)
 * [IBC Go](https://ibc.cosmos.network)
 * [Cosmos Hub](https://hub.cosmos.network)
@@ -11,8 +12,8 @@ The Cosmos org is collection of teams working on decentralized technology.
 
 ## Participate
 
+* [Cosmos Stack Discussions](https://github.com/orgs/cosmos/discussions)
 * [Cosmos Hub Forum](https://forum.cosmos.network)
-* [Cosmos Discussions](https://github.com/orgs/cosmos/discussions)
 
 ---
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -15,7 +15,7 @@ The Cosmos org is collection of teams working on decentralized technology.
 
 ## Participate
 
-* [Roadmaps](https://github.com/orgs/cosmos/projects)
+* [Cosmos Developers Discord](https://discord.com/invite/cosmosnetwork)
 * [Discussions & Product Feedback](https://github.com/orgs/cosmos/discussions)
 * [Cosmos Hub Forum](https://forum.cosmos.network)
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -2,17 +2,21 @@
 
 The Cosmos org is collection of teams working on decentralized technology.
 
-## Documentation
+## Quick Start
 
 * [Developer Portal](https://tutorials.cosmos.network/)
+
+## Documentation
+
 * [Cosmos SDK](https://docs.cosmos.network)
 * [IBC Go](https://ibc.cosmos.network)
-* [Cosmos Hub](https://hub.cosmos.network)
-* [Roadmaps](https://github.com/orgs/cosmos/projects)
+* [Cosmos Rust](https://github.com/cosmos/cosmos-rust/blob/main/README.md)
+* [CosmJS](https://tutorials.cosmos.network/tutorials/7-cosmjs/)
 
 ## Participate
 
-* [Cosmos Stack Discussions](https://github.com/orgs/cosmos/discussions)
+* [Roadmaps](https://github.com/orgs/cosmos/projects)
+* [Discussions & Product Feedback](https://github.com/orgs/cosmos/discussions)
 * [Cosmos Hub Forum](https://forum.cosmos.network)
 
 ---


### PR DESCRIPTION
Small idea on improving the profile page.
IMHO the repository list is a duplicate of the pinned repository, which makes me end-up reading the same info twice:

![image](https://user-images.githubusercontent.com/29894366/218256487-67da4800-3472-4b6a-b02a-670992859874.png)

Maybe adding a nice banner like https://github.com/github will make it look better too:

![image](https://user-images.githubusercontent.com/29894366/218256595-86c56363-7ba5-48e3-92e4-ee4c16a3cb6b.png)

